### PR TITLE
Master: add get_config()/set_config() support

### DIFF
--- a/src/vhost_user/master.rs
+++ b/src/vhost_user/master.rs
@@ -360,7 +360,8 @@ impl VhostUserMaster for Master {
         // "Master payload: virtio device config space"
         // But what content should the payload contains for a get_config() request?
         // So current implementation doesn't conform to the spec.
-        let hdr = node.send_request_with_body(MasterReq::GET_CONFIG, &body, None)?;
+        let buf = vec![0u8; body.size as usize];
+        let hdr = node.send_request_with_payload(MasterReq::GET_CONFIG, &body, &buf, None)?;
         let (reply, buf, rfds) = node.recv_reply_with_payload::<VhostUserConfig>(&hdr)?;
         if rfds.is_some() {
             Endpoint::<MasterReq>::close_rfds(rfds);
@@ -555,7 +556,7 @@ impl MasterInternal {
         if !reply.is_reply_for(hdr)
             || reply.get_size() as usize != mem::size_of::<T>() + bytes
             || rfds.is_some()
-            || body.is_valid()
+            || !body.is_valid()
         {
             Endpoint::<MasterReq>::close_rfds(rfds);
             return Err(VhostUserError::InvalidMessage);


### PR DESCRIPTION
@jiangliu 

Please help review this PR, and i copied this whole **src** into our cloud-hypervisor to verify it.

From the guest kernel log, we can get right virtio-blk config info from SPDK backend.

[    0.171460] -----------blk config value as below:--------------
[    0.172211] capacity=131072
[    0.172573] size_max=0
[    0.172886] seg_max=0
[    0.173183] blk_size=512
[    0.173519] physical_block_exp=0
[    0.173940] alignment_offset=0
[    0.174347] min_io_size=1
[    0.174692] opt_io_size=0
[    0.175045] wce=1
[    0.175301] num_queues=1
[    0.175616] max_discard_sectors=32768
[    0.176092] max_discard_seg=1
[    0.176473] discard_sector_alignment=1
[    0.176954] max_write_zeroes_sectors=1
[    0.177436] max_write_zeroes_seg=1
[    0.177881] write_zeroes_may_unmap=0
[    0.179780] virtio_blk virtio2: [vdb] 131072 512-byte logical blocks (67.1 MB/64.0 MiB)

This also can show right vdb info from guest
root@unicorn ~ # lsblk --output "NAME,KNAME,MODEL,HCTL,SIZE,VENDOR,SUBSYSTEMS"
NAME   KNAME  MODEL            HCTL        SIZE VENDOR   SUBSYSTEMS
sda    sda    scsi_debug       0:0:0:0       8M Linux    block:scsi:pseudo
nullb0 nullb0                              250G          block
vda    vda                                 8.5G 0x1af4   block:virtio:pci
├─vda1 vda1                                511M          block:virtio:pci
├─vda2 vda2                                 32M          block:virtio:pci
└─vda3 vda3                                  8G          block:virtio:pci
vdb    vdb                                  64M 0x1af4   block:virtio:pci  

